### PR TITLE
[BUGFIX] Fix MySQL-Error

### DIFF
--- a/Classes/Sitegeist/MagicWand/Command/CloneCommandController.php
+++ b/Classes/Sitegeist/MagicWand/Command/CloneCommandController.php
@@ -185,7 +185,7 @@ class CloneCommandController extends AbstractCommandController
         if ($keepDb == false) {
             $this->outputHeadLine('Drop and Recreate DB');
 
-            $emptyLocalDbSql = 'DROP DATABASE ' . $this->databaseConfiguration['dbname'] . '; CREATE DATABASE ' . $this->databaseConfiguration['dbname'] . ' collate utf8_unicode_ci;';
+            $emptyLocalDbSql = 'DROP DATABASE `' . $this->databaseConfiguration['dbname'] . '`; CREATE DATABASE `' . $this->databaseConfiguration['dbname'] . '` collate utf8_unicode_ci;';
             $this->executeLocalShellCommand(
                 'echo %s | mysql --host=%s --user=%s --password=%s',
                 [

--- a/Classes/Sitegeist/MagicWand/Command/StashCommandController.php
+++ b/Classes/Sitegeist/MagicWand/Command/StashCommandController.php
@@ -271,7 +271,7 @@ class StashCommandController extends AbstractCommandController
 
         if ($keepDb == false) {
             $this->outputHeadLine('Drop and Recreate DB');
-            $emptyLocalDbSql = 'DROP DATABASE ' . $this->databaseConfiguration['dbname'] . '; CREATE DATABASE ' . $this->databaseConfiguration['dbname'] . ' collate utf8_unicode_ci;';
+            $emptyLocalDbSql = 'DROP DATABASE `' . $this->databaseConfiguration['dbname'] . '`; CREATE DATABASE `' . $this->databaseConfiguration['dbname'] . '` collate utf8_unicode_ci;';
             $this->executeLocalShellCommand(
                 'echo %s | mysql --host=%s --user=%s --password=%s',
                 [


### PR DESCRIPTION
Without `` your SQL-Syntax is wrong, if you have an hyphen in your Database-Name

Example:
4. Drop and Recreate DB

echo 'DROP DATABASE test-datenbank; CREATE DATABASE test-datenbank collate utf8_unicode_ci;' | mysql --host=localhost --user=[xxx] --password=
ERROR 1064 (42000) at line 1: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-datenbank' at line 1