### PR TITLE
TASK: Add settings to configure the remote and the local flow-command

### DIFF
--- a/Classes/Sitegeist/MagicWand/Command/AbstractCommandController.php
+++ b/Classes/Sitegeist/MagicWand/Command/AbstractCommandController.php
@@ -38,6 +38,11 @@ abstract class AbstractCommandController extends CommandController
      */
     protected $secrets = [];
 
+    /**
+     * @var string
+     * @Flow\InjectConfiguration("flowCommand")
+     */
+    protected $flowCommand;
 
     /**
      * @param string $commands
@@ -75,7 +80,7 @@ abstract class AbstractCommandController extends CommandController
      */
     protected function executeLocalFlowCommand($command, $arguments = [], $options = [])
     {
-        $flowCommand = sprintf('./flow %s', $command);
+        $flowCommand = sprintf($this->flowCommand . ' %s', $command);
         return $this->executeLocalShellCommandWithFlowContext($flowCommand, $arguments, $options);
     }
 

--- a/Classes/Sitegeist/MagicWand/Command/CloneCommandController.php
+++ b/Classes/Sitegeist/MagicWand/Command/CloneCommandController.php
@@ -78,9 +78,10 @@ class CloneCommandController extends AbstractCommandController
                     $this->clonePresets[$presetName]['port'],
                     $this->clonePresets[$presetName]['path'],
                     $this->clonePresets[$presetName]['context'],
-                    (isset($this->clonePresets[$presetName]['postClone']) ? $this->clonePresets[$presetName]['postClone'] : NULL),
+                    (isset($this->clonePresets[$presetName]['postClone']) ? $this->clonePresets[$presetName]['postClone'] : null),
                     $yes,
-                    $keepDb
+                    $keepDb,
+                    (isset($this->clonePresets[$presetName]['flowCommand']) ? $this->clonePresets[$presetName]['flowCommand'] : null)
                 );
             } else {
                 $this->outputLine('The preset ' . $presetName . ' was not found!');
@@ -103,6 +104,7 @@ class CloneCommandController extends AbstractCommandController
      * @param mixded $postClone command or array of commands to be executed after cloning
      * @param boolean $yes confirm execution without further input
      * @param boolean $keepDb skip dropping of database during sync
+     * @param string $remoteFlowCommand the flow command to execute on the remote system
      */
     public function remoteHostCommand(
         $host,
@@ -110,10 +112,16 @@ class CloneCommandController extends AbstractCommandController
         $port,
         $path,
         $context = 'Production',
-        $postClone = NULL,
+        $postClone = null,
         $yes = false,
-        $keepDb = false
+        $keepDb = false,
+        $remoteFlowCommand = null
     ) {
+        // fallback
+        if ($remoteFlowCommand === null) {
+            $remoteFlowCommand = $this->flowCommand;
+        }
+
         // read local configuration
         $this->outputHeadLine('Read local configuration');
 
@@ -122,7 +130,7 @@ class CloneCommandController extends AbstractCommandController
         // read remote configuration
         $this->outputHeadLine('Fetch remote configuration');
         $remotePersistenceConfigurationYaml = $this->executeLocalShellCommand(
-            'ssh -p %s  %s@%s  "cd %s; FLOW_CONTEXT=%s ./flow configuration:show --type Settings --path TYPO3.Flow.persistence.backendOptions;"',
+            'ssh -p %s  %s@%s  "cd %s; FLOW_CONTEXT=%s ' . $remoteFlowCommand . ' configuration:show --type Settings --path TYPO3.Flow.persistence.backendOptions;"',
             [
                 $port,
                 $user,

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,5 +1,7 @@
 Sitegeist:
   MagicWand:
+    # the local flow command
+    flowCommand: './flow'
     clonePresets: []
 #      # the name of the preset for referencing on the clone:preset command
 #      master: 
@@ -13,6 +15,9 @@ Sitegeist:
 #        path: ~
 #        # flow-context on the remote server  
 #        context: Production
-#        # commands to execute after cloning      
+#        # the flow cli command on the remote server
+#        # default is the main flowCommand-Setting
+#        flowCommand: ~
+#        # commands to execute after cloning
 #        postClone:
 #         - './flow help'

--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ using the commands.**
 
 The presets that are defined in the configuration path. `Sitegeist.MagicWand.clonePresets`
 
-```
+```yaml
 Sitegeist:
   MagicWand:
+    flowCommand: './flow'
     clonePresets: []
 #      # the name of the preset for referencing on the clone:preset command
 #      master:
@@ -54,6 +55,9 @@ Sitegeist:
 #        # flow-context on the remote server  
 #        context: Production
 #        # commands to execute after cloning      
+#        # the flow cli command on the remote server
+#        # default is the main flowCommand-Setting
+#        flowCommand: ~ 
 #        postClone:
 #         - './flow help'
 ```


### PR DESCRIPTION
```
Sitegeist:
  MagicWand:
    flowCommand: './flow'
    clonePresets:
      master:
        flowCommand: './flow'
```

The package setting flowCommand is used as a fallback in the presets.