### PR TITLE
TASK: Remove master default of the clone preset command

### DIFF
--- a/Classes/Sitegeist/MagicWand/Command/CloneCommandController.php
+++ b/Classes/Sitegeist/MagicWand/Command/CloneCommandController.php
@@ -63,11 +63,11 @@ class CloneCommandController extends AbstractCommandController
     /**
      * Clone a flow setup as specified in Settings.yaml (Sitegeist.MagicWand.clonePresets ...)
      *
-     * @param string $presetName name of the preset from the settings, default: master
+     * @param string $presetName name of the preset from the settings
      * @param boolean $yes confirm execution without further input
      * @param boolean $keepDb skip dropping of database during sync
      */
-    public function presetCommand($presetName = 'master', $yes = false, $keepDb = false)
+    public function presetCommand($presetName, $yes = false, $keepDb = false)
     {
         if (count($this->clonePresets)>0 ) {
             if ($this->clonePresets && array_key_exists($presetName, $this->clonePresets)) {

--- a/README.md
+++ b/README.md
@@ -1,23 +1,4 @@
 # Sitegeist.MagicWand
-
-## Important Note:
-
-In the current release v1.0.4, we recognized an issue with the standard handling of parameters in Flow CLI. The following format currently does not work:
-
-```
-./flow clone:preset presetname
-```
-
-In order to make MagicWand work as expected, you'll instead have to use:
-
-```
-./flow clone:preset --preset-name presetname
-```
-
-v1.0.4 introduces the possibility to replace the standard flow command on remote systems, which sometimes becomes necessary in setups with multiple php versions (see #4). Also it fixes a issue with SQL statements, that were not properly escaped (see #3) If you don't require these features, you can decide to just skip this version until the next release.
-
-We're on it folks ;)
-
 ### Tools that make the Flow/Neos development easier
 
 This package is intended to be used on development systems and should **NEVER** be


### PR DESCRIPTION
With the default value and differing preset could only be added like this ``clone:preset --preset-name __your_name__``.
Before the preset name could be passed to the controller immediately ``clone:preset __your_name__`` we consider
this to be the most useful interface for this command so we revert the defaulr=master change.