### PR TITLE
BUGFIX: Escape remote mysql command to prevent issues with reserved c…

### DIFF
--- a/Classes/Sitegeist/MagicWand/Command/CloneCommandController.php
+++ b/Classes/Sitegeist/MagicWand/Command/CloneCommandController.php
@@ -195,7 +195,7 @@ class CloneCommandController extends AbstractCommandController
 
             $emptyLocalDbSql = 'DROP DATABASE `' . $this->databaseConfiguration['dbname'] . '`; CREATE DATABASE `' . $this->databaseConfiguration['dbname'] . '` collate utf8_unicode_ci;';
             $this->executeLocalShellCommand(
-                'echo %s | mysql --host=%s --user=%s --password=%s',
+                'echo %s | mysql --host=\'%s\' --user=\'%s\' --password=\'%s\'',
                 [
                     escapeshellarg($emptyLocalDbSql),
                     $this->databaseConfiguration['host'],
@@ -213,7 +213,7 @@ class CloneCommandController extends AbstractCommandController
 
         $this->outputHeadLine('Transfer Database');
         $this->executeLocalShellCommand(
-            'ssh -p %s %s@%s "mysqldump --add-drop-table --host=%s --user=%s --password=%s %s" | mysql --host=%s --user=%s --password=%s %s',
+            'ssh -p %s %s@%s \'mysqldump --add-drop-table --host=\'"\'"\'%s\'"\'"\' --user=\'"\'"\'%s\'"\'"\' --password=\'"\'"\'%s\'"\'"\' \'"\'"\'%s\'"\'"\'\' | mysql --host=\'%s\' --user=\'%s\' --password=\'%s\' \'%s\'',
             [
                 $port,
                 $user,


### PR DESCRIPTION
…haracters

This solves an issue, that came up with mysql passwords containing `$` as a character. Commands with those passwords
would fail, due to misinterpretation.

With this PR, the respective `mysqldump` command gets properly escaped.