### PR TITLE
Feature/add persistence backend option port

### DIFF
--- a/Classes/Sitegeist/MagicWand/Command/CloneCommandController.php
+++ b/Classes/Sitegeist/MagicWand/Command/CloneCommandController.php
@@ -188,10 +188,11 @@ class CloneCommandController extends AbstractCommandController
 
             $emptyLocalDbSql = 'DROP DATABASE `' . $this->databaseConfiguration['dbname'] . '`; CREATE DATABASE `' . $this->databaseConfiguration['dbname'] . '` collate utf8_unicode_ci;';
             $this->executeLocalShellCommand(
-                'echo %s | mysql --host=\'%s\' --user=\'%s\' --password=\'%s\'',
+                'echo %s | mysql --host=\'%s\' --port=\'%s\' --user=\'%s\' --password=\'%s\'',
                 [
                     escapeshellarg($emptyLocalDbSql),
                     $this->databaseConfiguration['host'],
+                    $this->databaseConfiguration['port'],
                     $this->databaseConfiguration['user'],
                     $this->databaseConfiguration['password']
                 ]
@@ -206,7 +207,7 @@ class CloneCommandController extends AbstractCommandController
 
         $this->outputHeadLine('Transfer Database');
         $this->executeLocalShellCommand(
-            'ssh -p %s %s@%s \'mysqldump --add-drop-table --host=\'"\'"\'%s\'"\'"\' --user=\'"\'"\'%s\'"\'"\' --password=\'"\'"\'%s\'"\'"\' \'"\'"\'%s\'"\'"\'\' | mysql --host=\'%s\' --user=\'%s\' --password=\'%s\' \'%s\'',
+            'ssh -p %s %s@%s \'mysqldump --add-drop-table --host=\'"\'"\'%s\'"\'"\' --user=\'"\'"\'%s\'"\'"\' --password=\'"\'"\'%s\'"\'"\' \'"\'"\'%s\'"\'"\'\' | mysql --host=\'%s\' --port=\'%s\' --user=\'%s\' --password=\'%s\' \'%s\'',
             [
                 $port,
                 $user,
@@ -216,6 +217,7 @@ class CloneCommandController extends AbstractCommandController
                 $remotePersistenceConfiguration['password'],
                 $remotePersistenceConfiguration['dbname'],
                 $this->databaseConfiguration['host'],
+                $this->databaseConfiguration['port'],
                 $this->databaseConfiguration['user'],
                 $this->databaseConfiguration['password'],
                 $this->databaseConfiguration['dbname']

--- a/Classes/Sitegeist/MagicWand/Command/CloneCommandController.php
+++ b/Classes/Sitegeist/MagicWand/Command/CloneCommandController.php
@@ -179,6 +179,14 @@ class CloneCommandController extends AbstractCommandController
 
         $this->checkConfiguration($remotePersistenceConfiguration);
 
+        ################################################
+        # Fallback to default MySQL port if not given. #
+        ################################################
+
+        if ( ! isset($this->databaseConfiguration['port'])) {
+            $this->databaseConfiguration['port'] = 3306;
+        }
+
         ########################
         # Drop and Recreate DB #
         ########################


### PR DESCRIPTION
MagicWand should use the database port if it is configured in persistence backend options. If no port is set,  the default 3306 is used.