### PR TITLE
FIX: Prevent table locks by using mysqldump --single-transaction

### DIFF
--- a/Classes/Sitegeist/MagicWand/Command/CloneCommandController.php
+++ b/Classes/Sitegeist/MagicWand/Command/CloneCommandController.php
@@ -236,7 +236,7 @@ class CloneCommandController extends AbstractCommandController
 
         $this->outputHeadLine('Transfer Database');
         $this->executeLocalShellCommand(
-            'ssh -p %s %s %s@%s \'mysqldump --add-drop-table --host=\'"\'"\'%s\'"\'"\' --port=\'"\'"\'%d\'"\'"\' --user=\'"\'"\'%s\'"\'"\' --password=\'"\'"\'%s\'"\'"\' \'"\'"\'%s\'"\'"\'\' | mysql --host=\'%s\' --port=\'%s\' --user=\'%s\' --password=\'%s\' \'%s\'',
+            'ssh -p %s %s %s@%s \'mysqldump --single-transaction --add-drop-table --host=\'"\'"\'%s\'"\'"\' --port=\'"\'"\'%d\'"\'"\' --user=\'"\'"\'%s\'"\'"\' --password=\'"\'"\'%s\'"\'"\' \'"\'"\'%s\'"\'"\'\' | mysql --host=\'%s\' --port=\'%s\' --user=\'%s\' --password=\'%s\' \'%s\'',
             [
                 $port,
                 $sshOptions,

--- a/Classes/Sitegeist/MagicWand/Command/StashCommandController.php
+++ b/Classes/Sitegeist/MagicWand/Command/StashCommandController.php
@@ -61,7 +61,7 @@ class StashCommandController extends AbstractCommandController
 
         $this->outputHeadLine('Backup Database');
         $this->executeLocalShellCommand(
-            'mysqldump --add-drop-table --host="%s" --user="%s" --password="%s" %s > %s',
+            'mysqldump --single-transaction --add-drop-table --host="%s" --user="%s" --password="%s" %s > %s',
             [
                 $this->databaseConfiguration['host'],
                 $this->databaseConfiguration['user'],


### PR DESCRIPTION
MagicWand should not lock the source database on clone. For InnoDB tables this can be archived by using transactions (`BEGIN`).