### PR TITLE
Add proxy assset support to stash feature

### DIFF
--- a/Classes/Command/AbstractCommandController.php
+++ b/Classes/Command/AbstractCommandController.php
@@ -9,10 +9,10 @@ namespace Sitegeist\MagicWand\Command;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Cli\CommandController;
+use Sitegeist\MagicWand\Domain\Service\ConfigurationService;
 
 abstract class AbstractCommandController extends CommandController
 {
-
     const HIDE_RESULT = 1;
     const HIDE_COMMAND = 2;
 

--- a/Classes/Command/AbstractCommandController.php
+++ b/Classes/Command/AbstractCommandController.php
@@ -45,6 +45,12 @@ abstract class AbstractCommandController extends CommandController
     protected $flowCommand;
 
     /**
+     * @Flow\Inject
+     * @var ConfigurationService
+     */
+    protected $configurationService;
+
+    /**
      * @param string $commands
      * @param array $arguments
      * @param array $options

--- a/Classes/Command/CloneCommandController.php
+++ b/Classes/Command/CloneCommandController.php
@@ -44,12 +44,6 @@ class CloneCommandController extends AbstractCommandController
     protected $dbal;
 
     /**
-     * @Flow\Inject
-     * @var ConfigurationService
-     */
-    protected $configurationService;
-
-    /**
      * Show the list of predefined clone configurations
      */
     public function listCommand()

--- a/Classes/Command/CloneCommandController.php
+++ b/Classes/Command/CloneCommandController.php
@@ -10,7 +10,6 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Utility\Arrays;
 use Neos\Flow\Core\Bootstrap;
 use Sitegeist\MagicWand\DBAL\SimpleDBAL;
-use Sitegeist\MagicWand\Domain\Service\ConfigurationService;
 use Symfony\Component\Yaml\Yaml;
 
 /**

--- a/Classes/Command/StashCommandController.php
+++ b/Classes/Command/StashCommandController.php
@@ -15,9 +15,6 @@ use Neos\Flow\Core\Bootstrap;
  */
 class StashCommandController extends AbstractCommandController
 {
-
-
-
     /**
      * Creates a new stash entry with the given name.
      *
@@ -277,7 +274,7 @@ class StashCommandController extends AbstractCommandController
                 . '`; CREATE DATABASE `'
                 . $this->databaseConfiguration['dbname']
                 . '` collate utf8_unicode_ci;';
-            
+
             $this->executeLocalShellCommand(
                 'echo %s | mysql --host=%s --user=%s --password=%s',
                 [

--- a/Classes/Domain/Service/ConfigurationService.php
+++ b/Classes/Domain/Service/ConfigurationService.php
@@ -20,16 +20,45 @@ class ConfigurationService
     protected $clonePresets;
 
     /**
+     * @return string
+     */
+    public function getCurrentPreset(): ?string
+    {
+        $clonePresetInformation = $this->clonePresetInformationCache->get('current');
+
+        if ($clonePresetInformation && is_array($clonePresetInformation) && isset($clonePresetInformation['presetName'])) {
+            return $clonePresetInformation['presetName'];
+        }
+
+        return null;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getMostRecentCloneTimeStamp(): ?int
+    {
+        $clonePresetInformation = $this->clonePresetInformationCache->get('current');
+
+        if ($clonePresetInformation && is_array($clonePresetInformation) && isset($clonePresetInformation['cloned_at'])) {
+            return intval($clonePresetInformation['cloned_at']);
+        }
+
+        return null;
+    }
+
+    /**
      * @return array
      */
     public function getCurrentConfiguration(): array
     {
-        $cloneInformation = $this->clonePresetInformationCache->get('current');
-        if ($cloneInformation && is_array($this->clonePresets) && array_key_exists($cloneInformation['presetName'], $this->clonePresets)) {
-            return $this->clonePresets[$cloneInformation['presetName']];
-        } else {
-            return [];
+        if ($presetName = $this->getCurrentPreset()) {
+            if (is_array($this->clonePresets) && array_key_exists($presetName, $this->clonePresets)) {
+                return $this->clonePresets[$presetName];
+            }
         }
+
+        return [];
     }
 
     /**
@@ -44,17 +73,56 @@ class ConfigurationService
     /**
      * @return boolean
      */
-    public function hasConfiguration(): bool
+    public function hasCurrentPreset(): bool
     {
-        return $this->clonePresetInformationCache->has('current');
+        if ($this->clonePresetInformationCache->has('current')) {
+            return true;
+        }
+
+        $clonePresetInformation = $this->clonePresetInformationCache->get('current');
+
+        if ($clonePresetInformation && is_array($clonePresetInformation) && isset($clonePresetInformation['presetName'])) {
+            return true;
+        }
+
+        return false;
     }
 
     /**
      * @param $presetName string
+     * @return void
      * @throws \Neos\Cache\Exception
      */
     public function setCurrentPreset(string $presetName): void
     {
-        $this->clonePresetInformationCache->set('current', ['presetName' => $presetName, 'timestamp' => time()]);
+        $this->clonePresetInformationCache->set('current', [
+            'presetName' => $presetName,
+            'cloned_at' => time()
+        ]);
+    }
+
+    /**
+     * @param string $stashEntryName
+     * @param array $stashEntryManifest
+     * @return void
+     * @throws \Neos\Cache\Exception
+     */
+    public function setCurrentStashEntry(string $stashEntryName, array $stashEntryManifest): void
+    {
+        if (!isset($stashEntryManifest['preset']['name'])) {
+            return;
+        }
+
+        if (!isset($stashEntryManifest['cloned_at'])) {
+            return;
+        }
+
+        $presetName = $stashEntryManifest['preset']['name'];
+        $clonedAt = $stashEntryManifest['cloned_at'];
+
+        $this->clonePresetInformationCache->set('current', [
+            'presetName' => $presetName,
+            'cloned_at' => $clonedAt
+        ]);
     }
 }

--- a/Classes/Domain/Service/ConfigurationService.php
+++ b/Classes/Domain/Service/ConfigurationService.php
@@ -24,9 +24,9 @@ class ConfigurationService
      */
     public function getCurrentConfiguration(): array
     {
-        $cloneInformations = $this->clonePresetInformationCache->get('current');
-        if ($cloneInformations && is_array($this->clonePresets) && array_key_exists($cloneInformations['presetName'], $this->clonePresets)) {
-            return $this->clonePresets[$cloneInformations['presetName']];
+        $cloneInformation = $this->clonePresetInformationCache->get('current');
+        if ($cloneInformation && is_array($this->clonePresets) && array_key_exists($cloneInformation['presetName'], $this->clonePresets)) {
+            return $this->clonePresets[$cloneInformation['presetName']];
         } else {
             return [];
         }


### PR DESCRIPTION
Every stash entry now gets a manifest file containing information about its source preset.  The preset is written to `Sitegeist_Magicwand_ClonePresetInformation` cache upon `stash:restore`.

`stash:list` reflects that information accordingly.

Also, the information formerly known as `timestamp` that is written to the persistent cache has been renamed to `cloned_at` for disambiguation.