### PR TITLE
BUGFIX: Avoid double sha in proxy resource uri when subdivideHashPathSegment segment is used

### DIFF
--- a/Classes/ResourceManagement/ProxyAwareWritableFileSystemStorage.php
+++ b/Classes/ResourceManagement/ProxyAwareWritableFileSystemStorage.php
@@ -67,7 +67,7 @@ class ProxyAwareWritableFileSystemStorage extends WritableFileSystemStorage
         $subdivideHashPathSegment = $resourceProxyConfiguration['subdivideHashPathSegment'] ?? false;
         if ($subdivideHashPathSegment) {
             $sha1Hash = $resource->getSha1();
-            $uri = $resourceProxyConfiguration['baseUri'] .'/_Resources/Persistent/' . $sha1Hash[0] . '/' . $sha1Hash[1] . '/' . $sha1Hash[2] . '/' . $sha1Hash[3] . '/' . $sha1Hash . '/' . $resource->getSha1() . '/' . rawurlencode($resource->getFilename());
+            $uri = $resourceProxyConfiguration['baseUri'] .'/_Resources/Persistent/' . $sha1Hash[0] . '/' . $sha1Hash[1] . '/' . $sha1Hash[2] . '/' . $sha1Hash[3] . '/' . $sha1Hash . '/' . rawurlencode($resource->getFilename());
         } else {
             $uri = $resourceProxyConfiguration['baseUri'] .'/_Resources/Persistent/' . $resource->getSha1() . '/' . rawurlencode($resource->getFilename());
         }


### PR DESCRIPTION
The handling of resource proxies was broken if `subdivideHashPathSegment` as the proxy url contained the sha twice.