### PR TITLE
BUGFIX: Render port number in mysql command as string

### DIFF
--- a/Classes/DBAL/SimpleDBAL.php
+++ b/Classes/DBAL/SimpleDBAL.php
@@ -40,7 +40,7 @@ class SimpleDBAL {
     public function buildDumpCmd(string $driver, ?string $host, int $port, string $username, string $password, string $database): string
     {
         if ($driver === 'pdo_mysql') {
-            return sprintf('mysqldump --single-transaction --add-drop-table --host=%s --port=%d --user=%s --password=%s %s', escapeshellarg($host), escapeshellarg($port), escapeshellarg($username), escapeshellarg($password), escapeshellarg($database));
+            return sprintf('mysqldump --single-transaction --add-drop-table --host=%s --port=%s --user=%s --password=%s %s', escapeshellarg($host), escapeshellarg($port), escapeshellarg($username), escapeshellarg($password), escapeshellarg($database));
         } else if ($driver === 'pdo_pgsql') {
             return sprintf('PGPASSWORD=%s pg_dump --host=%s --port=%s --username=%s --dbname=%s --schema=public --no-owner --no-privileges', escapeshellarg($password), escapeshellarg($host), escapeshellarg($port), escapeshellarg($username), escapeshellarg($database));
         }


### PR DESCRIPTION
Previously this was rendered as %d instead of %s which caused trouble becaued escapeshellarg returns a string.  This casused trouble for systems that did not use the dafault mysql port.