### PR TITLE
FEATURE: Exchangeable proxy aware storages and targets

### DIFF
--- a/Classes/ResourceManagement/ProxyAwareFileSystemSymlinkTarget.php
+++ b/Classes/ResourceManagement/ProxyAwareFileSystemSymlinkTarget.php
@@ -48,11 +48,12 @@ class ProxyAwareFileSystemSymlinkTarget extends FileSystemSymlinkTarget
      */
     protected $resourceManager;
 
-    public function initializeObject() {
-        // intialize uribuilder with request
+    public function initializeObject()
+    {
+        // initialize uriBuilder with request
         $requestHandler = $this->bootstrap->getActiveRequestHandler();
         if ($requestHandler instanceof HttpRequestHandlerInterface) {
-            $request = new ActionRequest($requestHandler->getHttpRequest());
+            $request = ActionRequest::fromHttpRequest($requestHandler->getComponentContext()->getHttpRequest());
             $this->uriBuilder->setRequest($request);
         }
         parent::initializeObject();

--- a/Classes/ResourceManagement/ProxyAwareFileSystemTarget.php
+++ b/Classes/ResourceManagement/ProxyAwareFileSystemTarget.php
@@ -1,14 +1,16 @@
 <?php
+declare(strict_types=1);
+
 namespace Sitegeist\MagicWand\ResourceManagement;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Flow\ResourceManagement\ResourceManager;
-use Neos\Flow\ResourceManagement\Target\FileSystemSymlinkTarget;
+use Neos\Flow\ResourceManagement\Target\FileSystemTarget;
 use Sitegeist\MagicWand\Domain\Service\ConfigurationService;
 
-class ProxyAwareFileSystemSymlinkTarget extends FileSystemSymlinkTarget implements ProxyAwareTargetInterface
+class ProxyAwareFileSystemTarget extends FileSystemTarget implements ProxyAwareTargetInterface
 {
     use ProxyAwareTargetTrait;
 

--- a/Classes/ResourceManagement/ProxyAwareStorageInterface.php
+++ b/Classes/ResourceManagement/ProxyAwareStorageInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Sitegeist\MagicWand\ResourceManagement;
+
+use Neos\Flow\ResourceManagement\ResourceMetaDataInterface;
+
+interface ProxyAwareStorageInterface
+{
+    public function resourceIsPresentInStorage(ResourceMetaDataInterface $resource): bool;
+}

--- a/Classes/ResourceManagement/ProxyAwareTargetInterface.php
+++ b/Classes/ResourceManagement/ProxyAwareTargetInterface.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Sitegeist\MagicWand\ResourceManagement;
+
+
+interface ProxyAwareTargetInterface
+{
+}

--- a/Classes/ResourceManagement/ProxyAwareTargetTrait.php
+++ b/Classes/ResourceManagement/ProxyAwareTargetTrait.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Sitegeist\MagicWand\ResourceManagement;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Http\Exception as HttpException;
+use Neos\Flow\Http\HttpRequestHandlerInterface;
+use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Mvc\Routing\Exception\MissingActionNameException;
+use Neos\Flow\Mvc\Routing\UriBuilder;
+use Neos\Flow\ResourceManagement\CollectionInterface;
+use Neos\Flow\ResourceManagement\PersistentResource;
+use Neos\Flow\ResourceManagement\ResourceManager;
+use Neos\Flow\ResourceManagement\Storage\StorageObject;
+use Neos\Flow\ResourceManagement\Target\Exception;
+use Sitegeist\MagicWand\Domain\Service\ConfigurationService;
+
+trait ProxyAwareTargetTrait
+{
+    public function initializeObject()
+    {
+        // initialize uriBuilder with request
+        $requestHandler = $this->bootstrap->getActiveRequestHandler();
+        if ($requestHandler instanceof HttpRequestHandlerInterface) {
+            $request = ActionRequest::fromHttpRequest($requestHandler->getComponentContext()->getHttpRequest());
+            $this->uriBuilder->setRequest($request);
+        }
+        parent::initializeObject();
+    }
+
+    /**
+     * @param CollectionInterface $collection The collection to publish
+     * @param callable $callback Function called after each resource publishing
+     * @return void
+     */
+    public function publishCollection(CollectionInterface $collection, callable $callback = null)
+    {
+        if (!$this->configurationService->getCurrentConfigurationByPath('resourceProxy')) {
+            parent::publishCollection($collection, $callback);
+            return;
+        }
+
+        /**
+         * @var ProxyAwareWritableFileSystemStorage $storage
+         */
+        $storage = $collection->getStorage();
+        if (!$storage instanceof ProxyAwareStorageInterface) {
+            parent::publishCollection($collection, $callback);
+            return;
+        }
+
+        foreach ($collection->getObjects($callback) as $object) {
+            /** @var StorageObject $object */
+            if ($storage->resourceIsPresentInStorage($object) === false) {
+                // this storage ignores resources that are not yet in the filesystem as they
+                // are optimistically created during read operations
+                continue;
+            }
+            $sourceStream = $object->getStream();
+            $this->publishFile($sourceStream, $this->getRelativePublicationPathAndFilename($object));
+            fclose($sourceStream);
+        }
+    }
+
+    /**
+     * @param PersistentResource $resource
+     * @return string
+     * @throws Exception
+     * @throws HttpException
+     * @throws MissingActionNameException
+     */
+    public function getPublicPersistentResourceUri(PersistentResource $resource)
+    {
+        if (!$this->configurationService->getCurrentConfigurationByPath('resourceProxy')) {
+            return parent::getPublicPersistentResourceUri($resource);
+        }
+
+        $collection = $this->resourceManager->getCollection($resource->getCollectionName());
+        $storage = $collection->getStorage();
+
+        if (!$storage instanceof ProxyAwareStorageInterface) {
+            return parent::getPublicPersistentResourceUri($resource);
+        }
+
+        if ($storage->resourceIsPresentInStorage($resource)) {
+            return parent::getPublicPersistentResourceUri($resource);
+        }
+
+        // build uri to resource controller that will fetch and publish
+        // the resource asynchronously
+        return $this->uriBuilder->uriFor(
+            'index',
+            ['resourceIdentifier' => $resource],
+            'Resource',
+            'Sitegeist.MagicWand'
+        );
+    }
+}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ section of your composer.json**.
 
 * Wilhelm Behncke - behncke@sitegeist.de
 * Martin Ficzel - ficzel@sitegeist.de
+* ... and others
 
 *The development and the public-releases of this package is generously sponsored by our employer https://www.sitegeist.de.*
 
@@ -107,6 +108,15 @@ the commands.**
 ./flow stash:clear
 ```
 **Note:** Use this command on a regular basis, because your stash tends to grow **very** large.
+
+## Resource proxies
+
+While cloning the database to your local dev system is manageable even for larger projects, downloading all the assets is often not an option.
+
+For this case the package offers the concept of resource proxies. Once activated, only the resources that are actually used are downloaded just at the moment they are rendered.
+This is done by custom implementations of `WritableFileSystemStorage` and `ProxyAwareFileSystemSymlinkTarget` and works out of the box if you use this storage and target in you local development environment.
+If you use other local storages, for example a local S3 storage, you can easily build your own proxy aware versions implementing the interfaces `ProxyAwareStorageInterface` and `ProxyAwareTargetInterface`of this package.
+
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "neos/flow": "~4.0 || ~5.0 || ~6.0 || dev-master"
+        "neos/flow": "~6.0 || dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
In a project we use a local S3 storage instead of the file system storage in order to be get the dev environment as similar as possible to the live environment. 

In order to use the resource proxy feature of magicwand I had to build a `MagicWandProxyAwareS3Storage` as well as a simple `ProxyAwareFileSystemTarget` (included). To make that possible, the code now checks for `ProxyAwareTargetInterface` and `ProxyAwareStorageInterface` instead of the provided implementations.

Also fixed some smaller bugs and did some boy-scout refactorings.