### PR TITLE
4.0

### DIFF
--- a/Classes/DBAL/SimpleDBAL.php
+++ b/Classes/DBAL/SimpleDBAL.php
@@ -40,7 +40,7 @@ class SimpleDBAL {
     public function buildDumpCmd(string $driver, ?string $host, int $port, string $username, string $password, string $database): string
     {
         if ($driver === 'pdo_mysql') {
-            return sprintf('mysqldump --single-transaction --add-drop-table --host=%s --port=%s --user=%s --password=%s %s', escapeshellarg($host), escapeshellarg($port), escapeshellarg($username), escapeshellarg($password), escapeshellarg($database));
+            return sprintf('mysqldump --single-transaction --add-drop-table --no-tablespaces --host=%s --port=%s --user=%s --password=%s %s', escapeshellarg($host), escapeshellarg($port), escapeshellarg($username), escapeshellarg($password), escapeshellarg($database));
         } else if ($driver === 'pdo_pgsql') {
             return sprintf('PGPASSWORD=%s pg_dump --host=%s --port=%s --username=%s --dbname=%s --schema=public --no-owner --no-privileges', escapeshellarg($password), escapeshellarg($host), escapeshellarg($port), escapeshellarg($username), escapeshellarg($database));
         }


### PR DESCRIPTION
**What I did**
I added the argument --no-tablespaces to the mysqldump command. Reason: In the latest mysql 5.7.31 patchlevel-update they introduced a breaking change that requires PROCESS privilege to run the mysqldump command if you call it without that argument.

**Sources**
https://dba.stackexchange.com/a/274460
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-31.html#mysqld-5-7-31-security

**Release request**
This merge request should result in two new releases:
4.0.x (i.e. 4.0.7) for Neos projects < 5.0
upmerge into master for 4.1.x (4.1.1) for Neos projects >= 5.0