### PR TITLE
FEATURE: Allow optional  key on resourceProxy configuration

### DIFF
--- a/Classes/ResourceManagement/ProxyAwareWritableFileSystemStorage.php
+++ b/Classes/ResourceManagement/ProxyAwareWritableFileSystemStorage.php
@@ -64,12 +64,13 @@ class ProxyAwareWritableFileSystemStorage extends WritableFileSystemStorage
         $browser = new Browser();
         $browser->setRequestEngine($curlEngine);
 
+        $subDirectory = $resourceProxyConfiguration['subDirectory'] ?? '_Resources/Persistent/';
         $subdivideHashPathSegment = $resourceProxyConfiguration['subdivideHashPathSegment'] ?? false;
         if ($subdivideHashPathSegment) {
             $sha1Hash = $resource->getSha1();
-            $uri = $resourceProxyConfiguration['baseUri'] .'/_Resources/Persistent/' . $sha1Hash[0] . '/' . $sha1Hash[1] . '/' . $sha1Hash[2] . '/' . $sha1Hash[3] . '/' . $sha1Hash . '/' . rawurlencode($resource->getFilename());
+            $uri = $resourceProxyConfiguration['baseUri'] . '/' . $subDirectory . $sha1Hash[0] . '/' . $sha1Hash[1] . '/' . $sha1Hash[2] . '/' . $sha1Hash[3] . '/' . $sha1Hash . '/' . rawurlencode($resource->getFilename());
         } else {
-            $uri = $resourceProxyConfiguration['baseUri'] .'/_Resources/Persistent/' . $resource->getSha1() . '/' . rawurlencode($resource->getFilename());
+            $uri = $resourceProxyConfiguration['baseUri'] . '/' . $subDirectory . $resource->getSha1() . '/' . rawurlencode($resource->getFilename());
         }
 
         $response = $browser->request($uri);

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -40,6 +40,7 @@ Sitegeist:
 #        # and instead resources are fetched and imported on the fly once read
 #        resourceProxy:
 #          baseUri: http://vour.server.tld
+#          subDirectory: _Resources/Persistent/
 #          subdivideHashPathSegment: false
 #          curlOptions:
 #            CURLOPT_USERPWD: very:secure

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Sitegeist:
         # and instead resources are fetched and imported on the fly once read
         resourceProxy:
           baseUri: http://vour.server.tld
+          # define an optional subDirectory (defaults to: '_Resources/Persistent/', trailing slash is required!)
+          subDirectory: '_Resources/Persistent/'
           # define wether or not the remote uses subdivideHashPathSegments
           subdivideHashPathSegment: false
           # curl options


### PR DESCRIPTION
If remote resources are stored in an S3 bucket, chances are, they will not be found under

```
http://vour.server.tld/_Resources/Persistent/...
```

 But directly beneath some CDN domain:
```
http://cdn.vour.server.tld/...
```

This PR introduces a `subDirectory` configuration key for resourceProxy configurations that defaults to `_Resources/Persistent/` (if the key isn't set at all). For the above scenario it can be set to an empty string, but it can also be configured to any other directory scheme.