### PR TITLE
Preserve Data\Persistent folder

### DIFF
--- a/Classes/Command/StashCommandController.php
+++ b/Classes/Command/StashCommandController.php
@@ -370,7 +370,7 @@ class StashCommandController extends AbstractCommandController
 
         $this->renderHeadLine('Restore Persistent Resources');
         $this->executeLocalShellCommand(
-            'rm -rf %s && cp -al %s %1$s',
+            'rm -rf %s/* && cp -al %s/* %1$s',
             [
                 FLOW_PATH_ROOT . 'Data/Persistent',
                 $source . '/persistent'


### PR DESCRIPTION
Currently `stash:restore` removes the folder `Data\Persistent` and re-creates it with the copy-command. This can break the setup when the folder `Data\Persistent` is a symlink (like in a typical setup when deploying with Surf).

This PR simply modifies the restore-command by deleting only the contents of the Persistent-folder and only copy the contents there afterwards, leaving the folder itself untouched.