### PR TITLE
TASK: Improve error message when remote configuration could not be read

### DIFF
--- a/Classes/Command/CloneCommandController.php
+++ b/Classes/Command/CloneCommandController.php
@@ -181,6 +181,9 @@ class CloneCommandController extends AbstractCommandController
 
         if ($remotePersistenceConfigurationYaml) {
             $remotePersistenceConfiguration = Yaml::parse($remotePersistenceConfigurationYaml);
+        } else {
+            $this->renderLine("<error>The remote configuration for %s@%s could not be read. Please check the configuration and ensure the correct ssh key was added.</error>", [$user, $host]);
+            $this->quit(1);
         }
         $remoteDataPersistentPath = $path . '/Data/Persistent';
 


### PR DESCRIPTION
Without this the code would run into an php error that can confuse users.