### PR TITLE
Kubernetes-Clone

### DIFF
--- a/Classes/Helper/KubernetesHelper.php
+++ b/Classes/Helper/KubernetesHelper.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+namespace Sitegeist\MagicWand\Helper;
+
+use RenokiCo\PhpK8s\Kinds\K8sDeployment;
+use RenokiCo\PhpK8s\Kinds\K8sPod;
+use RenokiCo\PhpK8s\KubernetesCluster;
+use Sitegeist\MagicWand\DBAL\SimpleDBAL;
+
+class KubernetesHelper {
+
+    const TMP_DUMP_FILE = '/tmp/k8s-dump.sql';
+
+    /**
+     * Get Pod from Kubernetes
+     *
+     * @param string $k8sConfigFilePath
+     * @param string $k8sConfigContext
+     * @param string $k8sNamespace
+     * @param string $k8sPodLabelSelector
+     * @return K8sPod
+     */
+    static public function getPod(
+        string $k8sConfigFilePath,
+        string $k8sConfigContext,
+        string $k8sNamespace,
+        string $k8sPodLabelSelector,
+    ) : K8sPod
+    {
+
+        //Get Cluster from config
+        $cluster = KubernetesCluster::fromKubeConfigYamlFile(
+            $k8sConfigFilePath,
+            $k8sConfigContext
+        );
+
+        //Configure Pod-selection
+        K8sDeployment::selectPods(function (K8sDeployment $dep) use ($k8sPodLabelSelector)
+        {
+            $labelSelectors = explode(',', $k8sPodLabelSelector);
+
+            $selectors = [];
+            foreach ($labelSelectors as $labelSelector) {
+                list($key, $value) = explode('=', $labelSelector);
+                $selectors[$key] = $value;
+            }
+            return $selectors;
+        });
+
+        /** @var K8sPod $pod */
+        return $cluster->deployment()->whereNamespace($k8sNamespace)->first()->getPods()->first();
+
+    }
+
+    /**
+     * @param K8sPod $pod
+     * @param string $containerName
+     * @param SimpleDBAL $dbal
+     * @param array $remotePersistenceConfiguration
+     * @param string|null $remoteDumpCommand
+     * @param array $tableContentToSkip
+     * @return string
+     * @throws \RenokiCo\PhpK8s\Exceptions\KubernetesAPIException
+     * @throws \RenokiCo\PhpK8s\Exceptions\KubernetesExecException
+     */
+    static public function downloadDataDump(
+        K8sPod $pod,
+        string $containerName,
+        SimpleDBAL $dbal,
+        array $remotePersistenceConfiguration,
+        string $remoteDumpCommand = null,
+        array $tableContentToSkip
+    ) : string
+    {
+        /** @var array $execResponse */
+        $execResponse = $pod->exec([
+            '/bin/bash', '-c',
+            $dbal->buildDataDumpCmd(
+                $remotePersistenceConfiguration['driver'],
+                $remotePersistenceConfiguration['host'],
+                (int)$remotePersistenceConfiguration['port'],
+                $remotePersistenceConfiguration['user'],
+                escapeshellcmd($remotePersistenceConfiguration['password']),
+                $remotePersistenceConfiguration['dbname'],
+                $remoteDumpCommand,
+                $tableContentToSkip
+            ),
+        ], $containerName);
+
+        if (file_exists(self::TMP_DUMP_FILE)) {
+            unlink(self::TMP_DUMP_FILE);
+        }
+
+        foreach ($execResponse as $res) {
+            file_put_contents(self::TMP_DUMP_FILE, $res['output'], FILE_APPEND);
+        }
+
+        return self::TMP_DUMP_FILE;
+    }
+
+    /**
+     * @param K8sPod $pod
+     * @param string $containerName
+     * @param SimpleDBAL $dbal
+     * @param array $remotePersistenceConfiguration
+     * @param string|null $remoteDumpCommand
+     * @param array $tableContentToSkip
+     * @return string
+     * @throws \RenokiCo\PhpK8s\Exceptions\KubernetesAPIException
+     * @throws \RenokiCo\PhpK8s\Exceptions\KubernetesExecException
+     */
+    static public function downloadSchemaDump(
+        K8sPod $pod,
+        string $containerName,
+        SimpleDBAL $dbal,
+        array $remotePersistenceConfiguration,
+        string $remoteDumpCommand = null,
+        array $tableContentToSkip
+    ) : string
+    {
+        /** @var array $execResponse */
+        $execResponse = $pod->exec([
+            '/bin/bash', '-c',
+            $dbal->buildDataDumpCmd(
+                $remotePersistenceConfiguration['driver'],
+                $remotePersistenceConfiguration['host'],
+                (int)$remotePersistenceConfiguration['port'],
+                $remotePersistenceConfiguration['user'],
+                escapeshellcmd($remotePersistenceConfiguration['password']),
+                $remotePersistenceConfiguration['dbname'],
+                $remoteDumpCommand,
+                $tableContentToSkip
+            ),
+        ], $containerName);
+
+        if (file_exists(self::TMP_DUMP_FILE)) {
+            unlink(self::TMP_DUMP_FILE);
+        }
+
+        foreach ($execResponse as $res) {
+            file_put_contents(self::TMP_DUMP_FILE, $res['output'], FILE_APPEND);
+        }
+
+        return self::TMP_DUMP_FILE;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -88,6 +88,28 @@ Sitegeist:
 The settings should be added to the global `Settings.yaml` of the project, so that every
 developer with SSH-access to the remote server can easily clone the setup.
 
+### Settings.yaml for clone from Kubernetes-Deployments
+Resources are not synchronized with a Kubernetes clone. This is the case, to make it compatible with infrastructures, where you don't have direct SSH-access into the container. (Only K8S API is used here). 
+In addition, outgoing traffic in Kubernetes clusters is usually subject to a charge, which also saves money. By using the resource proxy, however, this is not a problem and only the resources that are actually required are downloaded.
+
+Here is an example-config for Kubernetes-clone: 
+```yaml
+Sitegeist:
+  MagicWand:
+    clonePresets:
+      'CustomName':
+        k8sConfigFile: '/path/to/kubeconfig'
+        k8sContextName: 'cluster-user@cluster-name'
+        k8sNamespace: 'namespace-name'
+        k8sPodLabelSelector: 'app=xyz'
+        k8sContainerName: 'neos'
+        path: '/app'
+        context: 'Production'
+        resourceProxy:
+          baseUri: https://www.domain.tld
+          subDirectory: '_Resources/Persistent/'
+```
+
 ## Quick backup and restore mechanisms for persistent data
 
 Sometimes it's useful to quickly backup an integral persistent state of an application, to then perform some risky

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         }
     ],
     "require": {
+        "ext-yaml": "*",
         "neos/flow": "^7.0 || ^8.0 || dev-master"
     },
     "autoload": {


### PR DESCRIPTION
We love this package (Thanks BTW!) and wanted to use it for our new Kubernetes-based hosting. 
That's why I added a configuration option with Kubernetes. It only uses the Kubernetes API, so no SSH or similar needs to be used. Only the kubeconfig file needs to be available. 

At the same time, I have tried to extract some of the existing code into my own methods to make them easier to reuse. 

The exact configuration is explained in the README. The old config does not need to be adapted and all previous functions still work. 

I would be happy if we could get a new version of the MagicWand from this. 

Many thanks in advance! 