### PR TITLE
FIX no empty Array for default clonePresets

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -5,7 +5,7 @@ Sitegeist:
     flowCommand: './flow'
 #   # preset which is used by the clone:default command
 #   defaultPreset: 'master'
-    clonePresets: []
+#    clonePresets: []
 #      # the name of the preset for referencing on the clone:preset command
 #      master:
 #


### PR DESCRIPTION
This will reset all presets already set in other packages IF the package is loaded after another package. 
For example as a requirement in require-dev.