### PR TITLE
BUGFIX: Rsync with zsh

### DIFF
--- a/Classes/Command/CloneCommandController.php
+++ b/Classes/Command/CloneCommandController.php
@@ -342,7 +342,7 @@ class CloneCommandController extends AbstractCommandController
         if (!$resourceProxyConfiguration) {
             $this->renderHeadLine('Transfer Files');
             $this->executeLocalShellCommand(
-                'rsync -e "ssh -p %s %s" -kLr %s@%s:%s/* %s',
+                'rsync -e "ssh -p %s %s" -kLr %s@%s:"%s/*" %s',
                 [
                     $port,
                     addslashes($sshOptions),
@@ -355,7 +355,7 @@ class CloneCommandController extends AbstractCommandController
         } else {
             $this->renderHeadLine('Transfer Files - without Resources because a resourceProxyConfiguration is found');
             $this->executeLocalShellCommand(
-                'rsync -e "ssh -p %s %s" --exclude "Resources/*" -kLr %s@%s:%s/* %s',
+                'rsync -e "ssh -p %s %s" --exclude "Resources/*" -kLr %s@%s:"%s/*" %s',
                 [
                     $port,
                     addslashes($sshOptions),
@@ -391,7 +391,7 @@ class CloneCommandController extends AbstractCommandController
 
         if ($translationsAvailable === 'true') {
             $this->executeLocalShellCommand(
-                'rsync -e "ssh -p %s %s" -kLr %s@%s:%s/* %s',
+                'rsync -e "ssh -p %s %s" -kLr %s@%s:"%s/*" %s',
                 [
                     $port,
                     addslashes($sshOptions),


### PR DESCRIPTION
When running the sync command with zsh on the remote host, the glob doesn't match and the command hands without error. To fix this, the path needs to be quoted.

See https://github.com/ohmyzsh/ohmyzsh/issues/6813