### PR TITLE
BUGFIX: Set the presetName twice to avoid remote cache affecting preset name

### DIFF
--- a/Classes/Command/CloneCommandController.php
+++ b/Classes/Command/CloneCommandController.php
@@ -111,6 +111,8 @@ class CloneCommandController extends AbstractCommandController
                 $this->renderLine('The preset ' . $presetName . ' was not found!');
                 $this->quit(1);
             }
+
+            $this->configurationService->setCurrentPreset($presetName);
         } else {
             $this->renderLine('No presets found!');
             $this->quit(1);


### PR DESCRIPTION
When the cache files are copied during rsync, the local MagicWand data might get overwritten. Set the preset again to avoid that.

Also add some debug logs to see what is going on.